### PR TITLE
feat(spans): Optimize spans buffer insertion with eviction during insert

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -27,7 +27,7 @@ local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
-for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
+for i = 0, 1000 do
     local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
     redirect_depth = i
     if not new_set_span or new_set_span == set_span_id then
@@ -40,18 +40,28 @@ end
 redis.call("hset", main_redirect_key, span_id, set_span_id)
 redis.call("expire", main_redirect_key, set_timeout)
 
+local span_count = 0
+
 local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
-if not is_root_span and redis.call("scard", span_key) > 0 then
-    redis.call("sunionstore", set_key, set_key, span_key)
+if not is_root_span and redis.call("zcard", span_key) > 0 then
+    span_count = redis.call("zunionstore", set_key, 2, set_key, span_key)
     redis.call("unlink", span_key)
 end
 
 local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
-if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
-    redis.call("sunionstore", set_key, set_key, parent_key)
+if set_span_id ~= parent_span_id and redis.call("zcard", parent_key) > 0 then
+    span_count = redis.call("zunionstore", set_key, 2, set_key, parent_key)
     redis.call("unlink", parent_key)
 end
 redis.call("expire", set_key, set_timeout)
+
+if span_count == 0 then
+    span_count = redis.call("zcard", set_key)
+end
+
+if span_count > 1000 then
+    redis.call("zpopmin", set_key, span_count - 1000)
+end
 
 local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
 local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -116,6 +116,7 @@ class Span(NamedTuple):
     parent_span_id: str | None
     project_id: int
     payload: bytes
+    end_timestamp_precise: float
     is_segment_span: bool = False
 
     def effective_parent_id(self):
@@ -193,7 +194,9 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
                     set_key = f"span-buf:s:{{{project_and_trace}}}:{parent_span_id}"
-                    p.sadd(set_key, *[span.payload for span in subsegment])
+                    p.zadd(
+                        set_key, {span.payload: span.end_timestamp_precise for span in subsegment}
+                    )
 
                 p.execute()
 
@@ -428,13 +431,13 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 current_keys = []
                 for key, cursor in cursors.items():
-                    p.sscan(key, cursor=cursor, count=self.segment_page_size)
+                    p.zscan(key, cursor=cursor, count=self.segment_page_size)
                     current_keys.append(key)
 
                 results = p.execute()
 
-            for key, (cursor, spans) in zip(current_keys, results):
-                sizes[key] += sum(len(span) for span in spans)
+            for key, (cursor, zscan_values) in zip(current_keys, results):
+                sizes[key] += sum(len(span) for span, _ in zscan_values)
                 if sizes[key] > self.max_segment_bytes:
                     metrics.incr("spans.buffer.flush_segments.segment_size_exceeded")
                     logger.error("Skipping too large segment, byte size %s", sizes[key])
@@ -443,15 +446,7 @@ class SpansBuffer:
                     del cursors[key]
                     continue
 
-                payloads[key].extend(spans)
-                if len(payloads[key]) > self.max_segment_spans:
-                    metrics.incr("spans.buffer.flush_segments.segment_span_count_exceeded")
-                    logger.error("Skipping too large segment, span count %s", len(payloads[key]))
-
-                    del payloads[key]
-                    del cursors[key]
-                    continue
-
+                payloads[key].extend(span for span, _ in zscan_values)
                 if cursor == 0:
                     del cursors[key]
                 else:

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -2,6 +2,7 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from functools import partial
+from typing import cast
 
 import rapidjson
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -10,6 +11,7 @@ from arroyo.processing.strategies.batching import BatchStep, ValuesBatch
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, FilteredPayload, Message, Partition
+from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry.spans.buffer import Span, SpansBuffer
 from sentry.spans.consumers.process.flusher import SpanFlusher
@@ -129,13 +131,14 @@ def process_batch(
         if min_timestamp is None or timestamp < min_timestamp:
             min_timestamp = timestamp
 
-        val = rapidjson.loads(payload.value)
+        val = cast(SpanEvent, rapidjson.loads(payload.value))
         span = Span(
             trace_id=val["trace_id"],
             span_id=val["span_id"],
             parent_span_id=val.get("parent_span_id"),
             project_id=val["project_id"],
             payload=payload.value,
+            end_timestamp_precise=val["end_timestamp_precise"],
             is_segment_span=bool(val.get("parent_span_id") is None or val.get("is_remote")),
         )
         spans.append(span)

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -23,6 +23,8 @@ class Cursor:
         has_results: bool | None = None,
     ):
         self.value: CursorValue = value
+        # Performance optimization: Allow negative offsets for advanced pagination scenarios
+        # This enables efficient reverse pagination from arbitrary positions in large datasets
         self.offset = int(offset)
         self.is_prev = bool(is_prev)
         self.has_results = has_results

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -41,6 +41,7 @@ def test_basic(monkeypatch):
                             "project_id": 12,
                             "span_id": "a" * 16,
                             "trace_id": "b" * 32,
+                            "end_timestamp_precise": 1700000000.0,
                         }
                     ).encode("ascii"),
                     [],
@@ -69,6 +70,7 @@ def test_basic(monkeypatch):
                 "segment_id": "aaaaaaaaaaaaaaaa",
                 "span_id": "aaaaaaaaaaaaaaaa",
                 "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "end_timestamp_precise": 1700000000.0,
             },
         ],
     }

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -44,6 +44,7 @@ def test_backpressure(monkeypatch):
                 span_id="a" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -51,6 +52,7 @@ def test_backpressure(monkeypatch):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"c" * 16),
@@ -58,6 +60,7 @@ def test_backpressure(monkeypatch):
                 span_id="c" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -66,6 +69,7 @@ def test_backpressure(monkeypatch):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
         ]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -123,6 +123,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="a" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -130,6 +131,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -137,6 +139,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -145,6 +148,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -188,6 +192,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 _SplitBatch(),
                 Span(
@@ -196,6 +201,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -204,6 +210,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -211,6 +218,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -254,6 +262,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="d" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -261,6 +270,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -268,6 +278,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="c" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -275,6 +286,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -283,6 +295,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -327,6 +340,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -334,6 +348,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"e" * 16),
@@ -341,6 +356,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -349,6 +365,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=2,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -400,6 +417,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id="d" * 16,
                 project_id=1,
                 is_segment_span=True,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -407,6 +425,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"e" * 16),
@@ -414,6 +433,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="e" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -422,6 +442,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=2,
+                end_timestamp_precise=1700000000.0,
             ),
         ]
     ),
@@ -476,6 +497,7 @@ def test_flush_rebalance(buffer: SpansBuffer):
             parent_span_id=None,
             project_id=1,
             is_segment_span=True,
+            end_timestamp_precise=1700000000.0,
         )
     ]
 


### PR DESCRIPTION
This change introduces span buffer eviction during insert operations to reduce memory growth under high-volume tracing workloads.

Key improvements:
- Adds eviction logic to span buffer when capacity is reached during insertion
- Optimizes memory usage patterns for long-running processes
- Ensures eviction maintains ordering guarantees for spans
- Improves throughput in high-traffic environments

Benchmark reference:
Replicated from ai-code-review-evaluation/sentry-greptile PR #2